### PR TITLE
Refactor Vault integration (#202)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -25,95 +25,113 @@ It can also be passed as parameters to extensions like `FlaskDynaconf` or set in
 ## Configuration options
 
 ```eval_rst
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| Variable            | Type    | Usage                                            | default                                          | envvar example                                               |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| ROOT_PATH           | str     | | Directory to look for settings files           | | `None`                                         | ROOT_PATH_FOR_DYNACONF="/my/custom/absolute/path/"           |
-|                     |         | |                                                |                                                  |                                                              |
-|                     |         | | This path is the base to search for            | | If set Dynaconf will look this path first      |                                                              |
-|                     |         | | files defined in `SETTINGS_FILE`               | | before it starts to search for file in the     |                                                              |
-|                     |         | | Dynaconf will also search for files            | | other locations.                               |                                                              |
-|                     |         | | in a relative `config/` subfolder if exists.   | | see: `<usage.html#the-settings-files>`_        |                                                              |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| ENCODING            | str     | Encoding to read settings files                  | utf-8                                            | ENCODING_FOR_DYNACONF="cp1252"                               |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| ENVVAR              | str     | The envvar which holds the list of settings files| 'SETTINGS_FILE_FOR_DYNACONF'                     | ENVVAR_FOR_DYNACONF=MYPROGRAM_SETTINGS                       |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| SETTINGS_FILE       | list    | List of files to load                            | | List of all supportes files:                   || SETTINGS_FILE_FOR_DYNACONF="myconfig.toml"                  |
-|                     | str     |                                                  | | `settings.{py,toml,yaml,ini,conf,json}`        || SETTINGS_FILE_FOR_DYNACONF="['conf.toml','settings.yaml']"  |
-|                     |         |                                                  | | `.secrets.{py,toml,yaml,ini,conf,json}`        || SETTINGS_FILE_FOR_DYNACONF="conf.toml,settings.yaml"        |
-|                     |         |                                                  | |                                                || SETTINGS_FILE_FOR_DYNACONF="conf.toml;settings.yaml"        |
-|                     |         |                                                  | | This var name can be replaced by:              ||                                                             |
-|                     |         |                                                  | | `ENVVAR_FOR_DYNACONF=MYPROGRAM_SETTINGS`       || MYPROGRAM_SETTINGS="conf.toml,settings.yaml"                |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| SKIP_FILES          | list    | Files to skip/ignore if found on search tree     | []                                               | SKIP_FILES_FOR_DYNACONF="['/absolute/path/to/file.ext']"     |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| ENV                 | str     | Working environment                              | "development"                                    | ENV_FOR_DYNACONF=production                                  |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| ENV_SWITCHER        | str     | Variable used to change working env              | ENV_FOR_DYNACONF                                 | ENV_SWITCHER_FOR_DYNACONF=MYPROGRAM_ENV                      |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| ENVVAR_PREFIX       | str     | | Prefix for exporting parameters as env vars    | "DYNACONF"                                       || ENVVAR_PREFIX_FOR_DYNACONF=MYPROGRAM  (loads MYPROGRAM_VAR) |
-|                     |         | |                                                |                                                  ||                                                             |
-|                     |         | | Example:                                       |                                                  || ENVVAR_PREFIX_FOR_DYNACONF=''         (loads _VAR)          |
-|                     |         | | If your program is called `MYPROGRAM`          |                                                  || ENVVAR_PREFIX_FOR_DYNACONF=false      (loads VAR)           |
-|                     |         | | you may want users to use `MYPROGRAM_FOO=bar`  |                                                  |                                                              |
-|                     |         | | instead of `DYNACONF_FOO=bar` on envvars.      |                                                  |                                                              |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| SILENT_ERRORS       | bool    | Loading errors should be silenced                | true                                             | SILENT_ERRORS_FOR_DYNACONF=false                             |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| FRESH_VARS          | list    | A list of vars to be re-loaded on every access   | []                                               | FRESH_VARS_FOR_DYNACONF=["HOST", "PORT"]                     |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| DEBUG_LEVEL         | str     | Upper case logging level                         | NOTSET                                           | DEBUG_LEVEL_FOR_DYNACONF=DEBUG                               |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| DOTENV_PATH         | str     | defines where to look for `.env` file            | PROJECT_ROOT                                     | DOTENV_PATH_FOR_DYNACONF="/tmp/.env")                        |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| DOTENV_OVERRIDE     | bool    | `.env` should override the exported envvars      | false                                            | DOTENV_OVERRIDE_FOR_DYNACONF=true                            |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| AUTO_CAST           | bool    | `@casting` like `@int` is parsed                 | true                                             | DOTENV_OVERRIDE_FOR_DYNACONF=false                           |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| MERGE_ENABLED       | bool    | | Merge list/dict vars instead of overwriting.   | false                                            | MERGE_ENABLED_FOR_DYNACONF=true                              |
-| **deprecated**      |         |                                                  |                                                  |                                                              |
-|                     |         | | Use local merging instead                      |                                                  |                                                              |
-|                     |         | `<usage.html#merging-existing-values>`_          |                                                  |                                                              |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| REDIS_ENABLED       | bool    | Redis loader is enabled                          | false                                            | REDIS_ENABLED_FOR_DYNACONF=true                              |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| VAULT_ENABLED       | bool    | Vault server is enabled                          | false                                            | VAULT_ENABLED_FOR_DYNACONF=true                              |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| REDIS_HOST          | str     | Redis server address                             | localhost                                        | REDIS_HOST_FOR_DYNACONF="localhost"                          |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| REDIS_PORT          | int     | Redis port                                       | 6379                                             | REDIS_PORT_FOR_DYNACONF=8899                                 |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| REDIS_DB            | int     | Redis DB                                         | 0                                                | REDIS_DB_FOR_DYNACONF=1                                      |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| VAULT_URL           | str     | Vault URL                                        | http:// localhost :8200                          | VAULT_URL_FOR_DYNACONF="http://server/8200"                  |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| VAULT_TOKEN         | str     | vault token                                      | None                                             | VAULT_TOKEN_FOR_DYNACONF=myroot                              |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| VAULT_CERT          | str     | vault cert/pem file path                         | None                                             | VAULT_CERT_FOR_DYNACONF="~/.ssh/key.pem"                     |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| VAULT_VERIFY        | bool    | vault should verify                              | None                                             | VAULT_VERIFY_FOR_DYNACONF=true                               |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-|| INSTANCE           | str     || custom instance of LazySettings                 | None                                             | INSTANCE_FOR_DYNACONF=myapp.settings                         |
-|| **used only by**   |         || Must be an importable Python module             |                                                  |                                                              |
-|`$ dynaconf` **cli** |         |                                                  |                                                  |                                                              |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| YAML_LOADER         | str     | yaml method name {safe,full,unsafe}_load         | full_load                                        | YAML_LOADER_FOR_DYNACONF=unsafe_load                         |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| CORE_LOADERS        | list    | A list of enabled core loaders                   | ['YAML', 'TOML', 'INI', 'JSON', 'PY']            | CORE_LOADERS_FOR_DYNACONF='["YAML", "JSON"]' or '[]'         |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| LOADERS             | list    | A list of enabled external loaders               | ['dynaconf.loaders.env_loader']                  | LOADERS_FOR_DYNACONF='['module.mycustomloader', ...]'        |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| COMMENTJSON_ENABLED | bool    | Enable comments in json files                    | false  (req:`pip install commentjson`)           | COMMENTJSON_ENABLED_FOR_DYNACONF=true                        |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| SECRETS             | str     | Path to aditional secrets file to be loaded      | None                                             | SECRETS_FOR_DYNACONF=/var/jenkins/settings_ci.toml           |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| INCLUDES            | list    || A list of paths or a glob to load               | []                                               | INCLUDES_FOR_DYNACONF="['path1.ext', 'folder/*']"            |
-|                     |         || can be a toml-like list, or sep by , or ;       |                                                  | INCLUDES_FOR_DYNACONF="path1.toml;path2.toml"                |
-|                     |         ||                                                 |                                                  | INCLUDES_FOR_DYNACONF="path1.toml,path2.toml"                |
-|                     |         ||                                                 |                                                  | INCLUDES_FOR_DYNACONF="single_path.toml"                     |
-|                     |         ||                                                 |                                                  | INCLUDES_FOR_DYNACONF="single_path/glob/*.toml"              |
-+---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| Variable              | Type    | Usage                                            | default                                          | envvar example                                               |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| ROOT_PATH             | str     | | Directory to look for settings files           | | `None`                                         | ROOT_PATH_FOR_DYNACONF="/my/custom/absolute/path/"           |
+|                       |         | |                                                |                                                  |                                                              |
+|                       |         | | This path is the base to search for            | | If set Dynaconf will look this path first      |                                                              |
+|                       |         | | files defined in `SETTINGS_FILE`               | | before it starts to search for file in the     |                                                              |
+|                       |         | | Dynaconf will also search for files            | | other locations.                               |                                                              |
+|                       |         | | in a relative `config/` subfolder if exists.   | | see: `<usage.html#the-settings-files>`_        |                                                              |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| ENCODING              | str     | Encoding to read settings files                  | utf-8                                            | ENCODING_FOR_DYNACONF="cp1252"                               |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| ENVVAR                | str     | The envvar which holds the list of settings files| 'SETTINGS_FILE_FOR_DYNACONF'                     | ENVVAR_FOR_DYNACONF=MYPROGRAM_SETTINGS                       |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| SETTINGS_FILE         | list    | List of files to load                            | | List of all supportes files:                   | SETTINGS_FILE_FOR_DYNACONF="myconfig.toml"                  |
+|                       | str     |                                                  | | `settings.{py,toml,yaml,ini,conf,json}`        | SETTINGS_FILE_FOR_DYNACONF="['conf.toml','settings.yaml']"  |
+|                       |         |                                                  | | `.secrets.{py,toml,yaml,ini,conf,json}`        | SETTINGS_FILE_FOR_DYNACONF="conf.toml,settings.yaml"        |
+|                       |         |                                                  | |                                                | SETTINGS_FILE_FOR_DYNACONF="conf.toml;settings.yaml"        |
+|                       |         |                                                  | | This var name can be replaced by:              |                                                             |
+|                       |         |                                                  | | `ENVVAR_FOR_DYNACONF=MYPROGRAM_SETTINGS`       | MYPROGRAM_SETTINGS="conf.toml,settings.yaml"                |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| SKIP_FILES            | list    | Files to skip/ignore if found on search tree     | []                                               | SKIP_FILES_FOR_DYNACONF="['/absolute/path/to/file.ext']"     |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| ENV                   | str     | Working environment                              | "development"                                    | ENV_FOR_DYNACONF=production                                  |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| ENV_SWITCHER          | str     | Variable used to change working env              | ENV_FOR_DYNACONF                                 | ENV_SWITCHER_FOR_DYNACONF=MYPROGRAM_ENV                      |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| ENVVAR_PREFIX         | str     | | Prefix for exporting parameters as env vars    | "DYNACONF"                                       | ENVVAR_PREFIX_FOR_DYNACONF=MYPROGRAM  (loads MYPROGRAM_VAR) |
+|                       |         | |                                                |                                                  |                                                             |
+|                       |         | | Example:                                       |                                                  | ENVVAR_PREFIX_FOR_DYNACONF=''         (loads _VAR)          |
+|                       |         | | If your program is called `MYPROGRAM`          |                                                  | ENVVAR_PREFIX_FOR_DYNACONF=false      (loads VAR)           |
+|                       |         | | you may want users to use `MYPROGRAM_FOO=bar`  |                                                  |                                                              |
+|                       |         | | instead of `DYNACONF_FOO=bar` on envvars.      |                                                  |                                                              |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| SILENT_ERRORS         | bool    | Loading errors should be silenced                | true                                             | SILENT_ERRORS_FOR_DYNACONF=false                             |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| FRESH_VARS            | list    | A list of vars to be re-loaded on every access   | []                                               | FRESH_VARS_FOR_DYNACONF=["HOST", "PORT"]                     |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| DEBUG_LEVEL           | str     | Upper case logging level                         | NOTSET                                           | DEBUG_LEVEL_FOR_DYNACONF=DEBUG                               |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| DOTENV_PATH           | str     | defines where to look for `.env` file            | PROJECT_ROOT                                     | DOTENV_PATH_FOR_DYNACONF="/tmp/.env")                        |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| DOTENV_OVERRIDE       | bool    | `.env` should override the exported envvars      | false                                            | DOTENV_OVERRIDE_FOR_DYNACONF=true                            |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| AUTO_CAST             | bool    | `@casting` like `@int` is parsed                 | true                                             | DOTENV_OVERRIDE_FOR_DYNACONF=false                           |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| MERGE_ENABLED         | bool    | | Merge list/dict vars instead of overwriting.   | false                                            | MERGE_ENABLED_FOR_DYNACONF=true                              |
+| **deprecated**        |         |                                                  |                                                  |                                                              |
+|                       |         | | Use local merging instead                      |                                                  |                                                              |
+|                       |         | `<usage.html#merging-existing-values>`_          |                                                  |                                                              |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| REDIS_ENABLED         | bool    | Redis loader is enabled                          | false                                            | REDIS_ENABLED_FOR_DYNACONF=true                              |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| REDIS_HOST            | str     | Redis server address                             | localhost                                        | REDIS_HOST_FOR_DYNACONF="localhost"                          |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| REDIS_PORT            | int     | Redis port                                       | 6379                                             | REDIS_PORT_FOR_DYNACONF=8899                                 |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| REDIS_DB              | int     | Redis DB                                         | 0                                                | REDIS_DB_FOR_DYNACONF=1                                      |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_ENABLED         | bool    | Vault server is enabled                          | false                                            | VAULT_ENABLED_FOR_DYNACONF=true                              |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_URL             | str     | Vault URL                                        | http:// localhost :8200                          | VAULT_URL_FOR_DYNACONF="http://server/8200"                  |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_PATH            | str     | Vault path to the configuration                  | None                                             | VAULT_PATH_FOR_DYNACONF="secret_data"                        |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_TOKEN           | str     | Vault token                                      | None                                             | VAULT_TOKEN_FOR_DYNACONF="myroot"                            |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_SCHEME          | str     | Vault scheme                                     | http:                                            | VAULT_SCHEME_FOR_DYNACONF="https"                            |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_HOST            | str     | Vault host                                       | localhost                                        | VAULT_HOST_FOR_DYNACONF="server"                             |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_PORT            | str     | Vault port                                       | 8200                                             | VAULT_PORT_FOR_DYNACONF="2800"                               |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_TIMEOUT         | int     | Vault timeout in seconds                         | None                                             | VAULT_TIMEOUT_FOR_DYNACONF=60                                |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_PROXIES         | dict    | Vault proxies                                    | None                                             | VAULT_PROXIES_FOR_DYNACONF={http="http:/localhost:3128/"}    |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_ALLOW_REDIRECTS | bool    | Vault allow redirects                            | None                                             | VAULT_ALLOW_REDIRECTS_FOR_DYNACONF=false                     |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_CERT            | str     | Vault cert/pem file path                         | None                                             | VAULT_CERT_FOR_DYNACONF="~/.ssh/key.pem"                     |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_VERIFY          | bool    | Vault should verify                              | None                                             | VAULT_VERIFY_FOR_DYNACONF=true                               |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_ROLE_ID         | str     | Vault Role ID                                    | None                                             | VAULT_ROLE_ID_FOR_DYNACONF="some-role-id"                    |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| VAULT_SECRET_ID       | str     | Vault Secret ID                                  | None                                             | VAULT_SECRET_ID_FOR_DYNACONF="some-secret-id"                |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| INSTANCE              | str     | custom instance of LazySettings                  | None                                             | INSTANCE_FOR_DYNACONF=myapp.settings                         |
+| **used only by**      |         | Must be an importable Python module              |                                                  |                                                              |
+|`$ dynaconf` **cli**   |         |                                                  |                                                  |                                                              |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| YAML_LOADER           | str     | yaml method name {safe,full,unsafe}_load         | full_load                                        | YAML_LOADER_FOR_DYNACONF=unsafe_load                         |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| CORE_LOADERS          | list    | A list of enabled core loaders                   | ['YAML', 'TOML', 'INI', 'JSON', 'PY']            | CORE_LOADERS_FOR_DYNACONF='["YAML", "JSON"]' or '[]'         |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| LOADERS               | list    | A list of enabled external loaders               | ['dynaconf.loaders.env_loader']                  | LOADERS_FOR_DYNACONF='['module.mycustomloader', ...]'        |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| COMMENTJSON_ENABLED   | bool    | Enable comments in json files                    | false  (req:`pip install commentjson`)           | COMMENTJSON_ENABLED_FOR_DYNACONF=true                        |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| SECRETS               | str     | Path to aditional secrets file to be loaded      | None                                             | SECRETS_FOR_DYNACONF=/var/jenkins/settings_ci.toml           |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
+| INCLUDES              | list    | A list of paths or a glob to load                | []                                               | INCLUDES_FOR_DYNACONF="['path1.ext', 'folder/*']"            |
+|                       |         | can be a toml-like list, or sep by , or ;        |                                                  | INCLUDES_FOR_DYNACONF="path1.toml;path2.toml"                |
+|                       |         |                                                  |                                                  | INCLUDES_FOR_DYNACONF="path1.toml,path2.toml"                |
+|                       |         |                                                  |                                                  | INCLUDES_FOR_DYNACONF="single_path.toml"                     |
+|                       |         |                                                  |                                                  | INCLUDES_FOR_DYNACONF="single_path/glob/*.toml"              |
++-----------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
 ```
 
 ## Deprecated options

--- a/docs/guides/external_storages.md
+++ b/docs/guides/external_storages.md
@@ -117,7 +117,7 @@ Now you can have keys like `PASSWORD` and `TOKEN` defined in the vault and
 dynaconf will read it.
 
 To write a new secret you can use http://localhost:8200 web admin and write keys
-under the `/secret/dynaconf` secret database.
+under the `/secret/dynaconf/< env >` secret database.
 
 You can also use the Dynaconf writer via console
 

--- a/docs/guides/sensitive_secrets.md
+++ b/docs/guides/sensitive_secrets.md
@@ -46,7 +46,7 @@ Now you can have keys like `PASSWORD` and `TOKEN` defined in the vault and
 dynaconf will read it.
 
 To write a new secret you can use http://localhost:8200 web admin and write keys
-under the `/secret/dynaconf` secret database.
+under the `/secret/dynaconf/< env >` secret database.
 
 You can also use the Dynaconf writer via console
 

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -147,13 +147,12 @@ default_vault = {
     "timeout": get("VAULT_TIMEOUT_FOR_DYNACONF", None),
     "proxies": get("VAULT_PROXIES_FOR_DYNACONF", None),
     "allow_redirects": get("VAULT_ALLOW_REDIRECTS_FOR_DYNACONF", None),
-    "session": get("VAULT_SESSION_FOR_DYNACONF", None),
 }
 VAULT_FOR_DYNACONF = get("VAULT_FOR_DYNACONF", default_vault)
 VAULT_ENABLED_FOR_DYNACONF = get("VAULT_ENABLED_FOR_DYNACONF", False)
-VAULT_PATH_FOR_DYNACONF = get(
-    "VAULT_PATH_FOR_DYNACONF", "/secret/data/"
-)  # /DYNACONF will be added
+VAULT_PATH_FOR_DYNACONF = get("VAULT_PATH_FOR_DYNACONF", "dynaconf")
+VAULT_ROLE_ID_FOR_DYNACONF = get("VAULT_ROLE_ID_FOR_DYNACONF", None)
+VAULT_SECRET_ID_FOR_DYNACONF = get("VAULT_SECRET_ID_FOR_DYNACONF", None)
 
 # Only core loaders defined on this list will be invoked
 core_loaders = ["YAML", "TOML", "INI", "JSON", "PY"]

--- a/dynaconf/loaders/vault_loader.py
+++ b/dynaconf/loaders/vault_loader.py
@@ -45,9 +45,15 @@ def get_client(obj):
     client = Client(
         **{k: v for k, v in obj.VAULT_FOR_DYNACONF.items() if v is not None}
     )
-    assert (
-        client.is_authenticated()
-    ), "Vault authentication error is VAULT_TOKEN_FOR_DYNACONF defined?"
+    if obj.VAULT_ROLE_ID_FOR_DYNACONF is not None:
+        client.auth_approle(
+            role_id=obj.VAULT_ROLE_ID_FOR_DYNACONF,
+            secret_id=obj.get("VAULT_SECRET_ID_FOR_DYNACONF"),
+        )
+    assert client.is_authenticated(), (
+        "Vault authentication error: is VAULT_TOKEN_FOR_DYNACONF or "
+        "VAULT_ROLE_ID_FOR_DYNACONF defined?"
+    )
     return client
 
 


### PR DESCRIPTION
* Add AppRole based authorization for Vault loader

* Fix default value for VAULT_PATH_FOR_DYNACONF, Update docs

* HVAC automatically adds /secret/ prefix on read and write access
* /dynaconf was never added to the VAULT_PATH_FOR_DYNACONF value
* Docs was inconsistent with the actual code base

* Fix inconsistency in the docs

* Remove VAULT_SESSION_FOR_DYNACONF config variable.

* HVAC's session argument must be a fully initialized Session object,
that means - it's very complicated to setup Vault client with this
argument, via default instruments (.toml, .env, etc)
* Users can still setup this argument by setting up VAULT_FOR_DYNACONF
directly

* Update documentation for VAULT_* configuration

* Fix code style